### PR TITLE
continue button fixed in map when it's empty

### DIFF
--- a/src/common/MapAndQuestion.vue
+++ b/src/common/MapAndQuestion.vue
@@ -7,9 +7,11 @@ import { mapStyle } from '../assets/map/mapStyle';
 defineProps<{ config: MapAndQuestionInterface, showIcon: false }>();
 
 const { centerLocation } = storeToRefs(useResearchStore());
-const { setAnswersResearch, currentStepChild, treatment, dataOfResearch, currentStep } = useResearchStore();
+const { setAnswersResearch, setIsValidStep, currentStepChild, treatment, dataOfResearch, currentStep } = useResearchStore();
+setIsValidStep(false);
 
 const getAnswer = (event: any) => {
+    setIsValidStep(false);
     if (Math.sign(event?.target.value) === -1) {
         event.target.value = null;
         return;


### PR DESCRIPTION
La validación de isValidStep en el componente del mapa estaba dejando continuar a la siguiente pantalla sin haber escrito algo en el input de la cantidad de colegios.